### PR TITLE
test(command): add tests for privacy command

### DIFF
--- a/src/commands/bot/privacy.ts
+++ b/src/commands/bot/privacy.ts
@@ -1,6 +1,12 @@
 import CommandInt from "@Interfaces/CommandInt";
 import { MessageEmbed } from "discord.js";
 
+const PRIVACY_CONSTANTS = {
+  title: "Privacy Policy",
+  description:
+    "As part of my features, I collect and use some specific Discord related information. This information includes, but may not be limited to, your user name, nickname, and Discord ID. If you do not want this information to be collected, please use my `optout` command. This will disable some cool features for your account, like my levelling system! [View my full policy](https://github.com/nhcarrigan/BeccaBot/blob/main/PRIVACY.md)",
+};
+
 const privacy: CommandInt = {
   name: "privacy",
   description:
@@ -11,10 +17,8 @@ const privacy: CommandInt = {
     // Send an embed message to the current channel.
     await channel.send(
       new MessageEmbed()
-        .setTitle("Privacy Policy")
-        .setDescription(
-          "As part of my features, I collect and use some specific Discord related information. This information includes, but may not be limited to, your user name, nickname, and Discord ID. If you do not want this information to be collected, please use my `optout` command. This will disable some cool features for your account, like my levelling system! [View my full policy](https://github.com/nhcarrigan/BeccaBot/blob/main/PRIVACY.md)"
-        )
+        .setTitle(PRIVACY_CONSTANTS.title)
+        .setDescription(PRIVACY_CONSTANTS.description)
     );
   },
 };

--- a/test/unit/commands/bot/privacy.spec.ts
+++ b/test/unit/commands/bot/privacy.spec.ts
@@ -1,0 +1,60 @@
+import { expect } from "chai";
+import { MessageEmbed } from "discord.js";
+import { createSandbox, SinonStub } from "sinon";
+import cmd from "@Commands/bot/privacy";
+import { buildMessageInt } from "../../../testSetup";
+
+describe("command: privacy", () => {
+  let sandbox;
+  const testPrefix = "☂";
+  const botColor = "7B25AA";
+  const baseCommand = `${testPrefix}privacy`;
+
+  beforeEach(() => {
+    sandbox = createSandbox();
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  [
+    { name: "title", value: "Privacy Policy" },
+    {
+      name: "description",
+      value:
+        "As part of my features, I collect and use some specific Discord related information. This information includes, but may not be limited to, your user name, nickname, and Discord ID. If you do not want this information to be collected, please use my `optout` command. This will disable some cool features for your account, like my levelling system! [View my full policy](https://github.com/nhcarrigan/BeccaBot/blob/main/PRIVACY.md)",
+    },
+  ].forEach(({ name, value }) => {
+    it(`should set ${name} appropriately`, async () => {
+      const message = buildMessageInt(baseCommand, "", "", botColor);
+      const send: SinonStub = sandbox.stub();
+      message.channel.send = send;
+
+      await cmd.run(message);
+      const embed: MessageEmbed = send.firstCall.firstArg;
+      expect(embed[name]).to.equal(value);
+    });
+  });
+
+  context("when command followed by extra text", () => {
+    const inviteWithExtra = `${baseCommand} hello world`;
+    it("should call send", async () => {
+      const message = buildMessageInt(inviteWithExtra, "", "", botColor);
+      const send: SinonStub = sandbox.stub();
+      message.channel.send = send;
+
+      await cmd.run(message);
+
+      expect(send).to.be.called;
+    });
+  });
+  it("should call send", async () => {
+    const message = buildMessageInt(baseCommand, "", "", botColor);
+    const send: SinonStub = sandbox.stub();
+    message.channel.send = send;
+
+    await cmd.run(message);
+
+    expect(send).to.be.called;
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description:

Adds tests for the `privacy` functionality.

Note: The tests do not use the `PRIVACY_CONSTANT` on purpose so it is clear when values change the tests will fail.

## Related Issue:

Chips away at #199 

## Scope:

Did you remember to update the `package.json` version number?

- [ ] Major Version Update: X.\_.\_ (for complete code refactors, or large PRs that adjust most of the codebase)
- [ ] Minor Version Update: \_.X.\_ (for the addition of new commands)
- [ ] Patch Version Update: \_.\_.X (for bug fixes _in the code_.)
- [x] No Version Update: \_.\_.\_ (no version update for additions to tests, documentation, or anything that isn't end-user facing.)

## Documentation:

For _any_ version updates, please verify if the [documentation page](https://www.nhcarrigan.com/BeccaBot-documentation) needs an update. If it does, please [create an issue there](https://github.com/nhcarrigan/BeccaBot-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [x] My contribution does NOT require a documentation update.
- [ ] My contribution DOES require a documentation update.