### PR TITLE
test(command): add tests for report command

### DIFF
--- a/src/commands/bot/report.ts
+++ b/src/commands/bot/report.ts
@@ -1,6 +1,12 @@
 import CommandInt from "@Interfaces/CommandInt";
 import { MessageEmbed } from "discord.js";
 
+const REPORT_CONSTANTS = {
+  title: "Report a bug",
+  description:
+    "Did I do something wrong? Report an issue [here](https://github.com/nhcarrigan/BeccaBot/issues/choose).",
+};
+
 const report: CommandInt = {
   names: ["report", "bug", "issue"],
   description: "Generates a link to the issues page",
@@ -11,10 +17,8 @@ const report: CommandInt = {
     await channel.send(
       new MessageEmbed()
         .setColor(bot.color)
-        .setTitle("Report a bug")
-        .setDescription(
-          "Did I do something wrong? Report an issue [here](https://github.com/nhcarrigan/BeccaBot/issues/choose)."
-        )
+        .setTitle(REPORT_CONSTANTS.title)
+        .setDescription(REPORT_CONSTANTS.description)
     );
   },
 };

--- a/test/unit/commands/bot/report.spec.ts
+++ b/test/unit/commands/bot/report.spec.ts
@@ -1,0 +1,61 @@
+import { expect } from "chai";
+import { MessageEmbed } from "discord.js";
+import { createSandbox, SinonStub } from "sinon";
+import cmd from "@Commands/bot/report";
+import { buildMessageInt } from "../../../testSetup";
+
+describe("command: report", () => {
+  let sandbox;
+  const testPrefix = "☂";
+  const botColor = "7B25AA";
+  const baseCommand = `${testPrefix}report`;
+
+  beforeEach(() => {
+    sandbox = createSandbox();
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  [
+    { name: "color", value: parseInt(botColor, 16) },
+    { name: "title", value: "Report a bug" },
+    {
+      name: "description",
+      value:
+        "Did I do something wrong? Report an issue [here](https://github.com/nhcarrigan/BeccaBot/issues/choose).",
+    },
+  ].forEach(({ name, value }) => {
+    it(`should set ${name} appropriately`, async () => {
+      const message = buildMessageInt(baseCommand, "", "", botColor);
+      const send: SinonStub = sandbox.stub();
+      message.channel.send = send;
+
+      await cmd.run(message);
+      const embed: MessageEmbed = send.firstCall.firstArg;
+      expect(embed[name]).to.equal(value);
+    });
+  });
+
+  context("when command followed by extra text", () => {
+    const inviteWithExtra = `${baseCommand} hello world`;
+    it("should call send", async () => {
+      const message = buildMessageInt(inviteWithExtra, "", "", botColor);
+      const send: SinonStub = sandbox.stub();
+      message.channel.send = send;
+
+      await cmd.run(message);
+
+      expect(send).to.be.called;
+    });
+  });
+  it("should call send", async () => {
+    const message = buildMessageInt(baseCommand, "", "", botColor);
+    const send: SinonStub = sandbox.stub();
+    message.channel.send = send;
+
+    await cmd.run(message);
+
+    expect(send).to.be.called;
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description:

Adds tests for the `report` functionality.

Note: The tests do not use the `REPORT_CONSTANTS` on purpose so it is clear when values change the tests will fail.

## Related Issue:

Chips away at #199 

## Scope:

Did you remember to update the `package.json` version number?

- [ ] Major Version Update: X.\_.\_ (for complete code refactors, or large PRs that adjust most of the codebase)
- [ ] Minor Version Update: \_.X.\_ (for the addition of new commands)
- [ ] Patch Version Update: \_.\_.X (for bug fixes _in the code_.)
- [x] No Version Update: \_.\_.\_ (no version update for additions to tests, documentation, or anything that isn't end-user facing.)

## Documentation:

For _any_ version updates, please verify if the [documentation page](https://www.nhcarrigan.com/BeccaBot-documentation) needs an update. If it does, please [create an issue there](https://github.com/nhcarrigan/BeccaBot-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [x] My contribution does NOT require a documentation update.
- [ ] My contribution DOES require a documentation update.