### PR TITLE
test(command): add coverage over art

### DIFF
--- a/src/commands/bot/art.ts
+++ b/src/commands/bot/art.ts
@@ -2,6 +2,16 @@ import CommandInt from "@Interfaces/CommandInt";
 import { artList } from "@Utils/commands/artList";
 import { MessageAttachment, MessageEmbed } from "discord.js";
 
+const ART_CONSTANTS = {
+  error: "I am so sorry, but I cannot do that at the moment.",
+  title: "Art!",
+  description: (artist: string, artist_url: string): string =>
+    `Here is some Becca art! Art kindly done by [${artist}](${artist_url})!`,
+  attachment_name: "becca.png",
+  attachment_path: (file_name: string): string => `./img/${file_name}`,
+  image: "attachment://becca.png",
+};
+
 const art: CommandInt = {
   name: "art",
   description: "Returns art!",
@@ -15,18 +25,21 @@ const art: CommandInt = {
 
       //create embed
       const artEmbed = new MessageEmbed();
-      artEmbed.setTitle("Art!");
-      artEmbed.setDescription(
-        `Here is some Becca art! Art kindly done by [${artist}](${artist_url})!`
-      );
+      artEmbed.setTitle(ART_CONSTANTS.title);
+      artEmbed.setDescription(ART_CONSTANTS.description(artist, artist_url));
 
       //local files require a bit of hacking
       const attachment = [];
-      attachment.push(new MessageAttachment(`./img/${file_name}`, "becca.png"));
+      attachment.push(
+        new MessageAttachment(
+          ART_CONSTANTS.attachment_path(file_name),
+          ART_CONSTANTS.attachment_name
+        )
+      );
 
       //add local file
       artEmbed.attachFiles(attachment);
-      artEmbed.setImage("attachment://becca.png");
+      artEmbed.setImage(ART_CONSTANTS.image);
 
       //send it!
       await message.reply(artEmbed);
@@ -35,7 +48,7 @@ const art: CommandInt = {
         `${message.guild?.name} had this error with the art command:`
       );
       console.log(error);
-      message.reply("I am so sorry, but I cannot do that at the moment.");
+      message.reply(ART_CONSTANTS.error);
     }
   },
 };

--- a/test/unit/commands/bot/art.spec.ts
+++ b/test/unit/commands/bot/art.spec.ts
@@ -1,0 +1,70 @@
+import { expect } from "chai";
+import { createSandbox, SinonSpyCall } from "sinon";
+import { ImportMock } from "ts-mock-imports";
+import { artList } from "@Utils/commands/artList";
+import cmd from "@Commands/bot/art";
+import { buildMessageInt } from "../../../testSetup";
+import { MessageEmbed } from "discord.js";
+
+describe("command: art", () => {
+  let sandbox;
+  const testPrefix = "☂";
+  const botColor = "7B25AA";
+  const baseCommand = `${testPrefix}invite`;
+  const { file_name, artist, artist_url } = artList[0];
+
+  beforeEach(() => {
+    sandbox = createSandbox();
+    ImportMock.mockFunction(Math, "random", 0);
+  });
+  afterEach(() => {
+    ImportMock.restore();
+    sandbox.restore();
+  });
+
+  it("should reply", async () => {
+    const message = buildMessageInt(baseCommand, "", "", botColor);
+    message.reply = sandbox.stub();
+
+    await cmd.run(message);
+
+    expect(message.reply).calledOnce;
+  });
+  [
+    { name: "title", value: "Art!" },
+    { name: "image", value: { url: "attachment://becca.png" } },
+    {
+      name: "files",
+      value: [{ attachment: `./img/${file_name}`, name: "becca.png" }],
+    },
+    {
+      name: "description",
+      value: `Here is some Becca art! Art kindly done by [${artist}](${artist_url})!`,
+    },
+  ].forEach(({ name, value }) => {
+    it(`should set ${name} appropriately`, async () => {
+      const message = buildMessageInt(baseCommand, "", "", botColor);
+      message.reply = sandbox.stub();
+
+      await cmd.run(message);
+
+      const embed: MessageEmbed = message.reply.firstCall.firstArg;
+      expect(embed[name]).to.deep.equal(value);
+    });
+  });
+  context("when error is thrown", () => {
+    it("should reply standard error message", async () => {
+      const message = buildMessageInt(baseCommand, "", "", botColor);
+      message.reply = sandbox.stub();
+      message.reply.onFirstCall().rejects();
+      message.reply.onSecondCall().resolves();
+
+      await cmd.run(message);
+      expect(message.reply).calledTwice;
+      const secondCall: SinonSpyCall = message.reply.getCall(1);
+      expect(secondCall).calledWith(
+        "I am so sorry, but I cannot do that at the moment."
+      );
+    });
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description:

Adds test coverage over `art` command

Note: The tests do not use the `ART_CONSTANTS` on purpose so it is clear when values change the tests will fail.

## Related Issue:

Chips away at #199

## Scope:

Did you remember to update the `package.json` version number?

- [ ] Major Version Update: X.\_.\_ (for complete code refactors, or large PRs that adjust most of the codebase)
- [ ] Minor Version Update: \_.X.\_ (for the addition of new commands)
- [ ] Patch Version Update: \_.\_.X (for bug fixes _in the code_.)
- [x] No Version Update: \_.\_.\_ (no version update for additions to tests, documentation, or anything that isn't end-user facing.)

## Code Coverage:

Are all the unit tests passing and have you added tests that cover your changes? Run `npm run coverage`

Coverage Checklist:

- [x] All unit tests passing
- [x] Code that my PR modifies has tests.

## Documentation:

For _any_ version updates, please verify if the [documentation page](https://www.nhcarrigan.com/BeccaBot-documentation) needs an update. If it does, please [create an issue there](https://github.com/nhcarrigan/BeccaBot-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [x] My contribution does NOT require a documentation update.
- [ ] My contribution DOES require a documentation update.
