### PR TITLE
Test/cmd dnd

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "becca_bot",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/commands/games/dnd/dnd.ts
+++ b/src/commands/games/dnd/dnd.ts
@@ -1,6 +1,12 @@
 import CommandInt from "@Interfaces/CommandInt";
 import { MessageEmbed } from "discord.js";
 
+const DND_CONSTANTS = {
+  title: "Dungeons and Dragons!",
+  description: "Here are the `dnd` commands I know!",
+  error: "I am so sorry, but I cannot do that at the moment.",
+};
+
 const dnd: CommandInt = {
   name: "dnd",
   description: "List of the available Dungeons and Dragons commands",
@@ -18,10 +24,10 @@ const dnd: CommandInt = {
       const dndEmbed = new MessageEmbed();
 
       // Add the title.
-      dndEmbed.setTitle("Dungeons and Dragons!");
+      dndEmbed.setTitle(DND_CONSTANTS.title);
 
       // Add the description.
-      dndEmbed.setDescription("Here are the `dnd` commands I know!");
+      dndEmbed.setDescription(DND_CONSTANTS.description);
 
       // Get the available dnd commands.
       const dndCommands: Set<CommandInt> = new Set(
@@ -60,7 +66,7 @@ const dnd: CommandInt = {
         `${message.guild?.name} had the following error with the dnd command:`
       );
       console.log(error);
-      message.reply("I am so sorry, but I cannot do that at the moment.");
+      message.reply(DND_CONSTANTS.error);
     }
   },
 };

--- a/src/commands/games/dnd/dndclass.ts
+++ b/src/commands/games/dnd/dndclass.ts
@@ -3,6 +3,16 @@ import DndClassInt from "@Interfaces/commands/dnd/DndClassInt";
 import axios from "axios";
 import { MessageEmbed } from "discord.js";
 
+const DNDCLASS_CONSTANT = {
+  error: {
+    no_query: "Would you please provide the class you want me to search for?",
+    bad_data: "I am so sorry, but I was unable to find anything...",
+    default: "I am so sorry, but I cannot do that at the moment.",
+  },
+  dndApi: "https://www.dnd5eapi.co/api/classes/",
+  join_separator: ", ",
+};
+
 const dndclass: CommandInt = {
   name: "dndclass",
   description:
@@ -17,22 +27,18 @@ const dndclass: CommandInt = {
 
       // Check if the query is not empty.
       if (!query || !query.length) {
-        await message.reply(
-          "Would you please provide the class you want me to search for?"
-        );
+        await message.reply(DNDCLASS_CONSTANT.error.no_query);
         return;
       }
 
       // Get the data from the dnd api.
       const data = await axios.get<DndClassInt>(
-        `https://www.dnd5eapi.co/api/classes/${query}`
+        `${DNDCLASS_CONSTANT.dndApi}${query}`
       );
 
       // Check if the dnd class is not valid.
       if (!data.data || data.data.error) {
-        await message.reply(
-          "I am so sorry, but I was unable to find anything..."
-        );
+        await message.reply(DNDCLASS_CONSTANT.error.bad_data);
         return;
       }
 
@@ -59,23 +65,23 @@ const dndclass: CommandInt = {
       // Add the proficiencies to an embed field.
       dndClassEmbed.addField(
         "Proficiencies",
-        proficiencies.map((el) => el.name).join(", ")
+        proficiencies.map((el) => el.name).join(DNDCLASS_CONSTANT.join_separator)
       );
 
       // Add the proficiencies choices to an embed field.
       dndClassEmbed.addField(
         `Plus ${proficiency_choices[0].choose} from`,
-        proficiency_choices[0].from.map((el) => el.name).join(", ")
+        proficiency_choices[0].from.map((el) => el.name).join(DNDCLASS_CONSTANT.join_separator)
       );
 
       // Send the embed to the current channel.
       await channel.send(dndClassEmbed);
     } catch (error) {
-      console.log(
+      console.error(
         `${message.guild?.name} had the following error with the dndclass command:`
       );
-      console.log(error);
-      message.reply("I am so sorry, but I cannot do that at the moment.");
+      console.error(error);
+      message.reply(DNDCLASS_CONSTANT.error.default);
     }
   },
 };

--- a/src/commands/games/dnd/dndclass.ts
+++ b/src/commands/games/dnd/dndclass.ts
@@ -65,13 +65,17 @@ const dndclass: CommandInt = {
       // Add the proficiencies to an embed field.
       dndClassEmbed.addField(
         "Proficiencies",
-        proficiencies.map((el) => el.name).join(DNDCLASS_CONSTANT.join_separator)
+        proficiencies
+          .map((el) => el.name)
+          .join(DNDCLASS_CONSTANT.join_separator)
       );
 
       // Add the proficiencies choices to an embed field.
       dndClassEmbed.addField(
         `Plus ${proficiency_choices[0].choose} from`,
-        proficiency_choices[0].from.map((el) => el.name).join(DNDCLASS_CONSTANT.join_separator)
+        proficiency_choices[0].from
+          .map((el) => el.name)
+          .join(DNDCLASS_CONSTANT.join_separator)
       );
 
       // Send the embed to the current channel.

--- a/src/commands/games/dnd/dndmon.ts
+++ b/src/commands/games/dnd/dndmon.ts
@@ -3,6 +3,16 @@ import DndMonInt from "@Interfaces/commands/dnd/DndMonInt";
 import axios from "axios";
 import { MessageEmbed } from "discord.js";
 
+const DNDCLASS_CONSTANT = {
+  error: {
+    no_query: "Would you please provide the monster you want me to search for?",
+    bad_data: "I am so sorry, but I was unable to find anything...",
+    default: "I am so sorry, but I cannot do that at the moment.",
+  },
+  dndApi: "https://www.dnd5eapi.co/api/monsters/",
+  join_separator: ", ",
+};
+
 const dndmon: CommandInt = {
   names: ["dndmon", "dndmonster"],
   description:
@@ -17,22 +27,18 @@ const dndmon: CommandInt = {
 
       // Check if the query is not empty.
       if (!query || !query.length) {
-        await message.reply(
-          "Would you please provide the monster you want me to search for?"
-        );
+        await message.reply(DNDCLASS_CONSTANT.error.no_query);
         return;
       }
 
       // Get the data from the dnd api.
       const data = await axios.get<DndMonInt>(
-        `https://www.dnd5eapi.co/api/monsters/${query}`
+        `${DNDCLASS_CONSTANT.dndApi}${query}`
       );
 
       // Check if the dnd monster is not valid.
       if (!data.data || data.data.error) {
-        await message.reply(
-          "I am so sorry, but I was unable to find anything..."
-        );
+        await message.reply(DNDCLASS_CONSTANT.error.bad_data);
         return;
       }
 
@@ -86,7 +92,7 @@ const dndmon: CommandInt = {
         `${message.guild?.name} had the following error with the dndmon command:`
       );
       console.log(error);
-      message.reply("I am so sorry, but I cannot do that at the moment.");
+      message.reply(DNDCLASS_CONSTANT.error.default);
     }
   },
 };

--- a/src/commands/games/dnd/dndrace.ts
+++ b/src/commands/games/dnd/dndrace.ts
@@ -3,6 +3,42 @@ import axios from "axios";
 import DndRaceInt from "@Interfaces/commands/dnd/DndRaceInt";
 import { MessageEmbed } from "discord.js";
 
+const DNDRACE_CONST = {
+  fields: {
+    age: {
+      name: "Age",
+    },
+    alignment: {
+      name: "Alignment",
+    },
+    size: {
+      name: "Size",
+    },
+    language: {
+      name: "Language",
+    },
+    bonuses: {
+      name: "Bonuses",
+      transform: function (
+        data: Array<{ name: string; bonus: number }>
+      ): string {
+        return data.map((el) => `${el.name}: ${el.bonus}`).join(", ");
+      },
+    },
+    url: {
+      name: "URL",
+      transform: (data: string): string => {
+        return `https://www.dnd5eapi.co${data}`;
+      },
+    },
+  },
+  error: {
+    no_query: "Would you please provide the monster you want me to search for?",
+    bad_data: "I am so sorry, but I was unable to find anything...",
+    default: "I am so sorry, but I cannot do that at the moment.",
+  },
+};
+
 const dndrace: CommandInt = {
   name: "dndrace",
   description: "Gets information the provided Dungeons and Dragons **race**.",
@@ -16,9 +52,7 @@ const dndrace: CommandInt = {
 
       // Check if the query is not empty.
       if (!query || !query.length) {
-        await message.reply(
-          "Would you please provide the race you want me to search for?"
-        );
+        await message.reply(DNDRACE_CONST.error.no_query);
         return;
       }
 
@@ -29,9 +63,7 @@ const dndrace: CommandInt = {
 
       // Check if the dnd race is not valid.
       if (!data.data || data.data.error) {
-        await message.reply(
-          "I am so sorry, but I was unable to find anything..."
-        );
+        await message.reply(DNDRACE_CONST.error.bad_data);
         return;
       }
 
@@ -52,24 +84,24 @@ const dndrace: CommandInt = {
       dndRaceEmbed.setTitle(name);
 
       // Add the race url to the embed title url.
-      dndRaceEmbed.setURL(`https://www.dnd5eapi.co${url}`);
+      dndRaceEmbed.setURL(DNDRACE_CONST.fields.url.transform(url));
 
       // Add the race age to an embed field.
-      dndRaceEmbed.addField("Age", age);
+      dndRaceEmbed.addField(DNDRACE_CONST.fields.age.name, age);
 
       // Add the race alignment to an embed field.
-      dndRaceEmbed.addField("Alignment", alignment);
+      dndRaceEmbed.addField(DNDRACE_CONST.fields.alignment.name, alignment);
 
       // Add the race size description to an embed field.
-      dndRaceEmbed.addField("Size", size_description);
+      dndRaceEmbed.addField(DNDRACE_CONST.fields.size.name, size_description);
 
       // Add the race language to an embed field.
-      dndRaceEmbed.addField("Language", language_desc);
+      dndRaceEmbed.addField(DNDRACE_CONST.fields.language.name, language_desc);
 
       // Add the race bonuses to an embed field.
       dndRaceEmbed.addField(
-        "Bonuses",
-        ability_bonuses.map((el) => `${el.name}: ${el.bonus}`).join(", ")
+        DNDRACE_CONST.fields.bonuses.name,
+        DNDRACE_CONST.fields.bonuses.transform(ability_bonuses)
       );
 
       // Send the embed to the current channel.
@@ -79,7 +111,7 @@ const dndrace: CommandInt = {
         `${message.guild?.name} had the following error with the dndrace command:`
       );
       console.log(error);
-      message.reply("I am so sorry, but I cannot do that at the moment.");
+      message.reply(DNDRACE_CONST.error.default);
     }
   },
 };

--- a/src/commands/games/dnd/dndrace.ts
+++ b/src/commands/games/dnd/dndrace.ts
@@ -33,7 +33,7 @@ const DNDRACE_CONST = {
     },
   },
   error: {
-    no_query: "Would you please provide the monster you want me to search for?",
+    no_query: "Would you please provide the race you want me to search for?",
     bad_data: "I am so sorry, but I was unable to find anything...",
     default: "I am so sorry, but I cannot do that at the moment.",
   },

--- a/src/commands/games/dnd/dndschool.ts
+++ b/src/commands/games/dnd/dndschool.ts
@@ -3,6 +3,23 @@ import DndSchoolInt from "@Interfaces/commands/dnd/DndSchoolInt";
 import axios from "axios";
 import { MessageEmbed } from "discord.js";
 
+const DNDSCHOOL_CONST = {
+  fields: {
+    url: {
+      name: "URL",
+      transform: (data: string): string => {
+        return `https://www.dnd5eapi.co${data}`;
+      },
+    },
+  },
+  error: {
+    no_query:
+      "Would you please provide the school of magic you want me to search for?",
+    bad_data: "I am so sorry, but I was unable to find anything...",
+    default: "I am so sorry, but I cannot do that at the moment.",
+  },
+};
+
 const dndschool: CommandInt = {
   name: "dndschool",
   description:
@@ -17,9 +34,7 @@ const dndschool: CommandInt = {
 
       // Check if the query is not empty.
       if (!query || !query.length) {
-        await message.reply(
-          "Would you please provide the school of magic you want me to search for?"
-        );
+        await message.reply(DNDSCHOOL_CONST.error.no_query);
         return;
       }
 
@@ -30,9 +45,7 @@ const dndschool: CommandInt = {
 
       // Check if the dnd school is not valid.
       if (!data.data || data.data.error) {
-        await message.reply(
-          "I am so sorry, but I was unable to find anything..."
-        );
+        await message.reply(DNDSCHOOL_CONST.error.bad_data);
         return;
       }
 
@@ -45,7 +58,7 @@ const dndschool: CommandInt = {
       dndSchoolEmbed.setTitle(name);
 
       // Add the school url to the embed title url.
-      dndSchoolEmbed.setURL(`https://www.dnd5eapi.co${url}`);
+      dndSchoolEmbed.setURL(DNDSCHOOL_CONST.fields.url.transform(url));
 
       // Add the school description to the embed description.
       dndSchoolEmbed.setDescription(desc);
@@ -57,7 +70,7 @@ const dndschool: CommandInt = {
         `${message.guild?.name} had the following error with the dndschool command:`
       );
       console.log(error);
-      message.reply("I am so sorry, but I cannot do that at the moment.");
+      message.reply(DNDSCHOOL_CONST.error.default);
     }
   },
 };

--- a/src/commands/games/dnd/dndspell.ts
+++ b/src/commands/games/dnd/dndspell.ts
@@ -3,6 +3,22 @@ import DndSpellInt from "@Interfaces/commands/dnd/DndSpellInt";
 import axios from "axios";
 import { MessageEmbed } from "discord.js";
 
+const DNDSPELL_CONST = {
+  fields: {
+    components: {
+      name: "Components",
+      transform: (data: string[]): string => {
+        return data.join(", ");
+      },
+    },
+  },
+  error: {
+    no_query: "Would you please provide the spell you want me to search for?",
+    bad_data: "I am so sorry, but I was unable to find anything...",
+    default: "I am so sorry, but I cannot do that at the moment.",
+  },
+};
+
 const dndspell: CommandInt = {
   name: "dndspell",
   description:
@@ -17,9 +33,7 @@ const dndspell: CommandInt = {
 
       // Check if the query is not empty.
       if (!query || !query.length) {
-        await message.reply(
-          "Would you please provide the spell you want me to search for?"
-        );
+        await message.reply(DNDSPELL_CONST.error.no_query);
         return;
       }
 
@@ -30,9 +44,7 @@ const dndspell: CommandInt = {
 
       // Check if the dnd spell is not valid.
       if (!data.data || data.data.error) {
-        await message.reply(
-          "I am so sorry, but I was unable to find anything..."
-        );
+        await message.reply(DNDSPELL_CONST.error.bad_data);
         return;
       }
 
@@ -66,7 +78,10 @@ const dndspell: CommandInt = {
       dndSpellEmbed.addField("Material", material);
 
       // Add the spell components to an embed field.
-      dndSpellEmbed.addField("Components", components.join(", "));
+      dndSpellEmbed.addField(
+        "Components",
+        DNDSPELL_CONST.fields.components.transform(components)
+      );
 
       // Add the spell casting time to an embed field.
       dndSpellEmbed.addField("Casting time", casting_time);
@@ -81,7 +96,7 @@ const dndspell: CommandInt = {
         `${message.guild?.name} had the following error with the dndspell command:`
       );
       console.log(error);
-      message.reply("I am so sorry, but I cannot do that at the moment.");
+      message.reply(DNDSPELL_CONST.error.default);
     }
   },
 };

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -51,6 +51,12 @@ export const buildUserManager = (
   userCache.forEach(({ key, value }) => users.cache.set(key, value));
   return users;
 };
+
+export const buildGuild = () => {
+  const guild = mock<Guild>();
+  return guild;
+};
+
 export const buildMessage = (content: string): Message => {
   const msg = mock<Message>();
   msg.content = content;

--- a/test/testSetup.ts
+++ b/test/testSetup.ts
@@ -69,16 +69,19 @@ export const buildClientInt = ({
   channel,
   users,
   guilds,
+  prefix,
 }: {
   version: string;
   botColor: string;
   channel?: Channel;
   users?: UserManager;
   guilds?: GuildManager;
+  prefix?: string;
 }) => {
   const client: Client & ClientInt = mock<Client>();
   client.color = `#${botColor}`;
   client.version = version;
+  client.prefix = { default: prefix, server_id: prefix };
   if (channel) {
     client.channel = channel;
   }
@@ -95,7 +98,8 @@ export const buildMessageInt = (
   content: string,
   userId: string,
   authorName: string,
-  botColor = "000000"
+  botColor = "000000",
+  prefix = "☂"
 ): MessageInt => {
   const author: User = buildUser(userId, authorName);
   const channel: TextChannel = buildTextChannel();
@@ -107,11 +111,13 @@ export const buildMessageInt = (
     channel,
     users,
     guilds,
+    prefix,
   });
   const msg: Message & MessageInt = buildMessage(content);
   msg.author = author;
   msg.channel = channel;
   msg.bot = bot;
   msg.commandArguments = content.split(" ");
+  msg.commandName = msg.commandArguments.shift() || prefix;
   return msg as MessageInt;
 };

--- a/test/unit/commands/games/dnd/dnd.spec.ts
+++ b/test/unit/commands/games/dnd/dnd.spec.ts
@@ -1,0 +1,98 @@
+import { expect } from "chai";
+import { createSandbox, SinonSpyCall } from "sinon";
+import cmd from "@Commands/games/dnd/dnd";
+import { buildMessageInt, buildGuild } from "../../../../testSetup";
+import { Message, MessageEmbed } from "discord.js";
+import MessageInt from "@Interaces/MessageInt";
+
+describe("command: games/dnd/dnd", () => {
+  let sandbox;
+  const testPrefix = "☂";
+  const botColor = "7B25AA";
+  const baseCommand = `${testPrefix}dnd`;
+  const dndMsg = () => {
+    const message: Message & MessageInt = buildMessageInt(
+      baseCommand,
+      "",
+      "",
+      botColor
+    );
+    message.reply = sandbox.stub();
+    message.guild = buildGuild();
+    message.guild.id = "gid";
+    message.bot.commands = [
+      { name: "dnd yo", description: "one" },
+      { names: ["larry", "moe", "curly"], description: "not one" },
+      { names: ["hi", "ho", "dnd silver"], description: "two" },
+      { name: "dnd you", description: "three", parameters: [`<know>`] },
+    ];
+    message.bot.prefix = {
+      gid: testPrefix,
+      name: "TEST",
+    };
+    message.channel.send = sandbox.stub();
+
+    return message;
+  };
+
+  beforeEach(() => {
+    sandbox = createSandbox();
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  context("when no guild", () => {
+    it("should not send", async () => {
+      const message = dndMsg();
+      message.guild = undefined;
+
+      await cmd.run(message);
+
+      expect(message.channel.send).not.called;
+    });
+  });
+  it("should send", async () => {
+    const message = dndMsg();
+
+    await cmd.run(message);
+
+    expect(message.channel.send).calledOnce;
+  });
+  [
+    { name: "title", value: "Dungeons and Dragons!" },
+    {
+      name: "description",
+      value: "Here are the `dnd` commands I know!",
+    },
+    {
+      name: "fields",
+      value: [
+        { name: `${testPrefix}dnd yo`, value: "one", inline: false },
+        { name: `${testPrefix}hi/ho/dnd silver`, value: "two", inline: false },
+        { name: `${testPrefix}dnd you <know>`, value: "three", inline: false },
+      ],
+    },
+  ].forEach(({ name, value }) => {
+    it(`should set ${name} appropriately`, async () => {
+      const message = dndMsg();
+
+      await cmd.run(message);
+
+      const embed: MessageEmbed = message.channel.send.firstCall.firstArg;
+      expect(embed[name]).to.deep.equal(value);
+    });
+  });
+  context("when error is thrown", () => {
+    it("should reply standard error message", async () => {
+      const message = dndMsg();
+      message.channel.send.onFirstCall().rejects();
+      message.reply.onFirstCall().resolves();
+
+      await cmd.run(message);
+      expect(message.reply).calledWith(
+        "I am so sorry, but I cannot do that at the moment."
+      );
+    });
+  });
+});

--- a/test/unit/commands/games/dnd/dnd.spec.ts
+++ b/test/unit/commands/games/dnd/dnd.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { createSandbox, SinonSpyCall } from "sinon";
+import { createSandbox } from "sinon";
 import cmd from "@Commands/games/dnd/dnd";
 import { buildMessageInt, buildGuild } from "../../../../testSetup";
 import { Message, MessageEmbed } from "discord.js";

--- a/test/unit/commands/games/dnd/dndclass.spec.ts
+++ b/test/unit/commands/games/dnd/dndclass.spec.ts
@@ -1,0 +1,116 @@
+import { expect } from "chai";
+import { createSandbox, SinonSandbox } from "sinon";
+import { Message, MessageEmbed } from "discord.js";
+import axios from "axios";
+import { buildMessageInt } from "../../../../testSetup";
+import MessageInt from "@Interaces/MessageInt";
+import cmd from "@Commands/games/dnd/dndclass";
+
+describe("command: games/dnd/dnd", () => {
+  let sandbox: SinonSandbox;
+  const testPrefix = "☂";
+  const botColor = "7B25AA";
+  const baseCommand = `${testPrefix}dndclass`;
+  const dndclassMsg = (subcommand?) => {
+    const message: Message & MessageInt = buildMessageInt(
+      `${baseCommand}${subcommand ? ` ${subcommand}` : ""}`,
+      "",
+      "",
+      botColor,
+      testPrefix
+    );
+    message.reply = sandbox.stub();
+    message.channel.send = sandbox.stub();
+
+    return message;
+  };
+
+  beforeEach(() => {
+    sandbox = createSandbox();
+    sandbox.replace(console, "log", sandbox.stub());
+    sandbox.replace(console, "error", sandbox.stub());
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+  context("when no class supplied", () => {
+    it("should reply with error message", async () => {
+      const message = dndclassMsg("");
+      message.reply.resolves();
+
+      await cmd.run(message);
+
+      expect(message.reply).calledWith(
+        "Would you please provide the class you want me to search for?"
+      );
+    });
+  });
+  context("when get fails", () => {
+    it("should reply with error message", async () => {
+      const dndClass = "programmer";
+      const get = sandbox.stub();
+      sandbox.replace(axios, "get", get);
+      const message = dndclassMsg(dndClass);
+      message.reply.resolves();
+
+      await cmd.run(message);
+
+      expect(message.reply).calledWith(
+        "I am so sorry, but I cannot do that at the moment."
+      );
+    });
+  });
+  context("when get succeeds but data has an error", () => {
+    it("should reply with error message", async () => {
+      const dndClass = "programmer";
+      const get = sandbox.stub();
+      get.resolves({ data: { error: true } });
+      sandbox.replace(axios, "get", get);
+      const message = dndclassMsg(dndClass);
+      message.reply.resolves();
+
+      await cmd.run(message);
+
+      expect(message.reply).calledWith(
+        "I am so sorry, but I was unable to find anything..."
+      );
+    });
+  });
+  context("when get succeeds", () => {
+    it("should set embedded message correctly", async () => {
+      const dndClass = "programmer";
+      const classData = {
+        hit_die: "blue",
+        name: "Grand Lord Programmer",
+        proficiencies: [
+          { name: "TDD" },
+          { name: "Lean" },
+          { name: "Design Patterns" },
+        ],
+        proficiency_choices: [
+          {
+            choose: "apple",
+            from: [{ name: "barrel" }, { name: "tree" }, { name: "bowl" }],
+          },
+        ],
+        url: "/api/classes/programmer",
+      };
+      const get = sandbox.stub();
+      get.resolves({ data: classData });
+      sandbox.replace(axios, "get", get);
+      const message = dndclassMsg(dndClass);
+      message.channel.send.resolves();
+
+      const expectedMsg = new MessageEmbed();
+      expectedMsg.setTitle(classData.name);
+      expectedMsg.setURL(`https://www.dnd5eapi.co${classData.url}`);
+      expectedMsg.addField("Hit die", classData.hit_die);
+      expectedMsg.addField("Proficiencies", "TDD, Lean, Design Patterns");
+      expectedMsg.addField("Plus apple from", "barrel, tree, bowl");
+
+      await cmd.run(message);
+
+      expect(message.channel.send).calledWith(expectedMsg);
+    });
+  });
+});

--- a/test/unit/commands/games/dnd/dndmon.spec.ts
+++ b/test/unit/commands/games/dnd/dndmon.spec.ts
@@ -4,13 +4,13 @@ import { Message, MessageEmbed } from "discord.js";
 import axios from "axios";
 import { buildMessageInt } from "../../../../testSetup";
 import MessageInt from "@Interaces/MessageInt";
-import cmd from "@Commands/games/dnd/dndclass";
+import cmd from "@Commands/games/dnd/dndmon";
 
-describe("command: games/dnd/dndclass", () => {
+describe("command: games/dnd/dndmon", () => {
   let sandbox: SinonSandbox;
   const testPrefix = "☂";
   const botColor = "7B25AA";
-  const baseCommand = `${testPrefix}dndclass`;
+  const baseCommand = `${testPrefix}dndmon`;
   const dndclassMsg = (subcommand?) => {
     const message: Message & MessageInt = buildMessageInt(
       `${baseCommand}${subcommand ? ` ${subcommand}` : ""}`,
@@ -41,7 +41,7 @@ describe("command: games/dnd/dndclass", () => {
       await cmd.run(message);
 
       expect(message.reply).calledWith(
-        "Would you please provide the class you want me to search for?"
+        "Would you please provide the monster you want me to search for?"
       );
     });
   });
@@ -80,20 +80,19 @@ describe("command: games/dnd/dndclass", () => {
     it("should set embedded message correctly", async () => {
       const dndClass = "programmer";
       const classData = {
-        hit_die: "blue",
-        name: "Grand Lord Programmer",
-        proficiencies: [
-          { name: "TDD" },
-          { name: "Lean" },
-          { name: "Design Patterns" },
-        ],
-        proficiency_choices: [
-          {
-            choose: "apple",
-            from: [{ name: "barrel" }, { name: "tree" }, { name: "bowl" }],
-          },
-        ],
-        url: "/api/classes/programmer",
+        alignment: "skewed",
+        armor_class: "light",
+        challenge_rating: "Infinite",
+        charisma: "99",
+        constitution: "98",
+        dexterity: "98",
+        intelligence: "999",
+        name: "Demon Lord Programmmer",
+        strength: "over 9000",
+        subtype: "Wizard",
+        type: "Robot",
+        url: "blue",
+        wisdom: "95",
       };
       const get = sandbox.stub();
       get.resolves({ data: classData });
@@ -104,10 +103,14 @@ describe("command: games/dnd/dndclass", () => {
       const expectedMsg = new MessageEmbed();
       expectedMsg.setTitle(classData.name);
       expectedMsg.setURL(`https://www.dnd5eapi.co${classData.url}`);
-      expectedMsg.addField("Hit die", classData.hit_die);
-      expectedMsg.addField("Proficiencies", "TDD, Lean, Design Patterns");
-      expectedMsg.addField("Plus apple from", "barrel, tree, bowl");
-
+      expectedMsg.addField("Challenge rating", classData.challenge_rating);
+      expectedMsg.addField("Type", `${classData.type} - ${classData.subtype}`);
+      expectedMsg.addField("Alignment", classData.alignment);
+      expectedMsg.addField(
+        "Attributes",
+        `STR: ${classData.strength}, DEX: ${classData.dexterity}, CON: ${classData.constitution}, INT: ${classData.intelligence}, WIS: ${classData.wisdom}, CHA: ${classData.charisma}`
+      );
+      expectedMsg.addField("Armour class", classData.armor_class);
       await cmd.run(message);
 
       expect(message.channel.send).calledWith(expectedMsg);

--- a/test/unit/commands/games/dnd/dndrace.spec.ts
+++ b/test/unit/commands/games/dnd/dndrace.spec.ts
@@ -1,0 +1,115 @@
+import { expect } from "chai";
+import { createSandbox, SinonSandbox } from "sinon";
+import { Message, MessageEmbed } from "discord.js";
+import axios from "axios";
+import { buildMessageInt } from "../../../../testSetup";
+import MessageInt from "@Interaces/MessageInt";
+import cmd from "@Commands/games/dnd/dndrace";
+
+describe("command: games/dnd/race", () => {
+  let sandbox: SinonSandbox;
+  const testPrefix = "☂";
+  const botColor = "7B25AA";
+  const baseCommand = `${testPrefix}dndrace`;
+  const dndclassMsg = (subcommand?) => {
+    const message: Message & MessageInt = buildMessageInt(
+      `${baseCommand}${subcommand ? ` ${subcommand}` : ""}`,
+      "",
+      "",
+      botColor,
+      testPrefix
+    );
+    message.reply = sandbox.stub();
+    message.channel.send = sandbox.stub();
+
+    return message;
+  };
+
+  beforeEach(() => {
+    sandbox = createSandbox();
+    sandbox.replace(console, "log", sandbox.stub());
+    sandbox.replace(console, "error", sandbox.stub());
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+  context("when no class supplied", () => {
+    it("should reply with error message", async () => {
+      const message = dndclassMsg("");
+      message.reply.resolves();
+
+      await cmd.run(message);
+
+      expect(message.reply).calledWith(
+        "Would you please provide the monster you want me to search for?"
+      );
+    });
+  });
+  context("when get fails", () => {
+    it("should reply with error message", async () => {
+      const dndClass = "programmer";
+      const get = sandbox.stub();
+      sandbox.replace(axios, "get", get);
+      const message = dndclassMsg(dndClass);
+      message.reply.resolves();
+
+      await cmd.run(message);
+
+      expect(message.reply).calledWith(
+        "I am so sorry, but I cannot do that at the moment."
+      );
+    });
+  });
+  context("when get succeeds but data has an error", () => {
+    it("should reply with error message", async () => {
+      const dndClass = "programmer";
+      const get = sandbox.stub();
+      get.resolves({ data: { error: true } });
+      sandbox.replace(axios, "get", get);
+      const message = dndclassMsg(dndClass);
+      message.reply.resolves();
+
+      await cmd.run(message);
+
+      expect(message.reply).calledWith(
+        "I am so sorry, but I was unable to find anything..."
+      );
+    });
+  });
+  context("when get succeeds", () => {
+    it("should set embedded message correctly", async () => {
+      const dndClass = "programmer";
+      const data = {
+        ability_bonuses: [
+          { name: "Lean+", bonus: 5 },
+          { name: "Waterfall", bonus: -15 },
+        ],
+        alignment: "skewed",
+        age: "Ageless",
+        language_desc:
+          "TypeScript extends JavaScript by adding types to the language. TypeScript speeds up your development experience by catching errors and providing fixes before you even run your code",
+        name: "Programmer",
+        size_description: "Amorphous",
+        url: "/programmer",
+      };
+      const get = sandbox.stub();
+      get.resolves({ data });
+      sandbox.replace(axios, "get", get);
+      const message = dndclassMsg(dndClass);
+      message.channel.send.resolves();
+
+      const expectedMsg = new MessageEmbed();
+      expectedMsg.setTitle(data.name);
+      expectedMsg.setURL(`https://www.dnd5eapi.co${data.url}`);
+      expectedMsg.addField("Age", data.age);
+      expectedMsg.addField("Alignment", data.alignment);
+      expectedMsg.addField("Size", data.size_description);
+      expectedMsg.addField("Language", data.language_desc);
+      expectedMsg.addField("Bonuses", "Lean+: 5, Waterfall: -15");
+
+      await cmd.run(message);
+
+      expect(message.channel.send).calledWith(expectedMsg);
+    });
+  });
+});

--- a/test/unit/commands/games/dnd/dndrace.spec.ts
+++ b/test/unit/commands/games/dnd/dndrace.spec.ts
@@ -6,7 +6,7 @@ import { buildMessageInt } from "../../../../testSetup";
 import MessageInt from "@Interaces/MessageInt";
 import cmd from "@Commands/games/dnd/dndrace";
 
-describe("command: games/dnd/race", () => {
+describe("command: games/dnd/dndrace", () => {
   let sandbox: SinonSandbox;
   const testPrefix = "☂";
   const botColor = "7B25AA";
@@ -41,7 +41,7 @@ describe("command: games/dnd/race", () => {
       await cmd.run(message);
 
       expect(message.reply).calledWith(
-        "Would you please provide the monster you want me to search for?"
+        "Would you please provide the race you want me to search for?"
       );
     });
   });

--- a/test/unit/commands/games/dnd/dndschool.spec.ts
+++ b/test/unit/commands/games/dnd/dndschool.spec.ts
@@ -1,0 +1,103 @@
+import { expect } from "chai";
+import { createSandbox, SinonSandbox } from "sinon";
+import { Message, MessageEmbed } from "discord.js";
+import axios from "axios";
+import { buildMessageInt } from "../../../../testSetup";
+import MessageInt from "@Interaces/MessageInt";
+import cmd from "@Commands/games/dnd/dndschool";
+
+describe("command: games/dnd/dndschool", () => {
+  let sandbox: SinonSandbox;
+  const testPrefix = "☂";
+  const botColor = "7B25AA";
+  const baseCommand = `${testPrefix}dndschool`;
+  const dndclassMsg = (subcommand?) => {
+    const message: Message & MessageInt = buildMessageInt(
+      `${baseCommand}${subcommand ? ` ${subcommand}` : ""}`,
+      "",
+      "",
+      botColor,
+      testPrefix
+    );
+    message.reply = sandbox.stub();
+    message.channel.send = sandbox.stub();
+
+    return message;
+  };
+
+  beforeEach(() => {
+    sandbox = createSandbox();
+    sandbox.replace(console, "log", sandbox.stub());
+    sandbox.replace(console, "error", sandbox.stub());
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+  context("when no school supplied", () => {
+    it("should reply with error message", async () => {
+      const message = dndclassMsg("");
+      message.reply.resolves();
+
+      await cmd.run(message);
+
+      expect(message.reply).calledWith(
+        "Would you please provide the school of magic you want me to search for?"
+      );
+    });
+  });
+  context("when get fails", () => {
+    it("should reply with error message", async () => {
+      const dndClass = "programmer";
+      const get = sandbox.stub();
+      sandbox.replace(axios, "get", get);
+      const message = dndclassMsg(dndClass);
+      message.reply.resolves();
+
+      await cmd.run(message);
+
+      expect(message.reply).calledWith(
+        "I am so sorry, but I cannot do that at the moment."
+      );
+    });
+  });
+  context("when get succeeds but data has an error", () => {
+    it("should reply with error message", async () => {
+      const dndClass = "programmer";
+      const get = sandbox.stub();
+      get.resolves({ data: { error: true } });
+      sandbox.replace(axios, "get", get);
+      const message = dndclassMsg(dndClass);
+      message.reply.resolves();
+
+      await cmd.run(message);
+
+      expect(message.reply).calledWith(
+        "I am so sorry, but I was unable to find anything..."
+      );
+    });
+  });
+  context("when get succeeds", () => {
+    it("should set embedded message correctly", async () => {
+      const dndClass = "programmer";
+      const data = {
+        name: "Design Patterns",
+        desc: "Improved code quality",
+        url: "/programmer",
+      };
+      const get = sandbox.stub();
+      get.resolves({ data });
+      sandbox.replace(axios, "get", get);
+      const message = dndclassMsg(dndClass);
+      message.channel.send.resolves();
+
+      const expectedMsg = new MessageEmbed();
+      expectedMsg.setTitle(data.name);
+      expectedMsg.setURL(`https://www.dnd5eapi.co${data.url}`);
+      expectedMsg.setDescription(data.desc);
+
+      await cmd.run(message);
+
+      expect(message.channel.send).calledWith(expectedMsg);
+    });
+  });
+});

--- a/test/unit/commands/games/dnd/dndspell.spec.ts
+++ b/test/unit/commands/games/dnd/dndspell.spec.ts
@@ -1,0 +1,113 @@
+import { expect } from "chai";
+import { createSandbox, SinonSandbox } from "sinon";
+import { Message, MessageEmbed } from "discord.js";
+import axios from "axios";
+import { buildMessageInt } from "../../../../testSetup";
+import MessageInt from "@Interaces/MessageInt";
+import cmd from "@Commands/games/dnd/dndspell";
+
+describe("command: games/dnd/dndspell", () => {
+  let sandbox: SinonSandbox;
+  const testPrefix = "☂";
+  const botColor = "7B25AA";
+  const baseCommand = `${testPrefix}dndspell`;
+  const dndclassMsg = (subcommand?) => {
+    const message: Message & MessageInt = buildMessageInt(
+      `${baseCommand}${subcommand ? ` ${subcommand}` : ""}`,
+      "",
+      "",
+      botColor,
+      testPrefix
+    );
+    message.reply = sandbox.stub();
+    message.channel.send = sandbox.stub();
+
+    return message;
+  };
+
+  beforeEach(() => {
+    sandbox = createSandbox();
+    sandbox.replace(console, "log", sandbox.stub());
+    sandbox.replace(console, "error", sandbox.stub());
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+  context("when no school supplied", () => {
+    it("should reply with error message", async () => {
+      const message = dndclassMsg("");
+      message.reply.resolves();
+
+      await cmd.run(message);
+
+      expect(message.reply).calledWith(
+        "Would you please provide the spell you want me to search for?"
+      );
+    });
+  });
+  context("when get fails", () => {
+    it("should reply with error message", async () => {
+      const dndClass = "programmer";
+      const get = sandbox.stub();
+      sandbox.replace(axios, "get", get);
+      const message = dndclassMsg(dndClass);
+      message.reply.resolves();
+
+      await cmd.run(message);
+
+      expect(message.reply).calledWith(
+        "I am so sorry, but I cannot do that at the moment."
+      );
+    });
+  });
+  context("when get succeeds but data has an error", () => {
+    it("should reply with error message", async () => {
+      const dndClass = "programmer";
+      const get = sandbox.stub();
+      get.resolves({ data: { error: true } });
+      sandbox.replace(axios, "get", get);
+      const message = dndclassMsg(dndClass);
+      message.reply.resolves();
+
+      await cmd.run(message);
+
+      expect(message.reply).calledWith(
+        "I am so sorry, but I was unable to find anything..."
+      );
+    });
+  });
+  context("when get succeeds", () => {
+    it("should set embedded message correctly", async () => {
+      const dndClass = "programmer";
+      const data = {
+        casting_time: "2 mins",
+        components: ["wand", "pumpkin", "dog", "clothing", "mice"],
+        desc: ["Transforms pumpkins, mice, dogs, and clothing for a ball"],
+        higher_level: ["not sure"],
+        material: "Pumpkins",
+        name: "bibbidi-bobbidi-boo",
+        range: "Small yard",
+        school: { name: "Fairy godmother" },
+      };
+      const get = sandbox.stub();
+      get.resolves({ data });
+      sandbox.replace(axios, "get", get);
+      const message = dndclassMsg(dndClass);
+      message.channel.send.resolves();
+
+      const expectedMsg = new MessageEmbed();
+      expectedMsg.setTitle(data.name);
+      expectedMsg.setDescription(data.desc[0]);
+      expectedMsg.addField("Higher level casting", "not sure");
+      expectedMsg.addField("School", "Fairy godmother");
+      expectedMsg.addField("Material", "Pumpkins");
+      expectedMsg.addField("Components", "wand, pumpkin, dog, clothing, mice");
+      expectedMsg.addField("Casting time", "2 mins");
+      expectedMsg.addField("Range", "Small yard");
+
+      await cmd.run(message);
+
+      expect(message.channel.send).calledWith(expectedMsg);
+    });
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description:

Adds tests for the `dnd`, `dndclass`, `dndspell`, `dndschool`, `dndmon`, and `dndrace` functionality.

Note: The tests do not use the `DND*_CONSTANTS` on purpose so it is clear when values change the tests will fail.

### Followup

There's a lot of repeated code between these commands. I think we should pull out the common code/constants to refactor these. Might even be worth making a client lib.

## Related Issue:

Chips away at #199 

## Scope:

Did you remember to update the `package.json` version number?

- [ ] Major Version Update: X.\_.\_ (for complete code refactors, or large PRs that adjust most of the codebase)
- [ ] Minor Version Update: \_.X.\_ (for the addition of new commands)
- [ ] Patch Version Update: \_.\_.X (for bug fixes _in the code_.)
- [x] No Version Update: \_.\_.\_ (no version update for additions to tests, documentation, or anything that isn't end-user facing.)

## Documentation:

For _any_ version updates, please verify if the [documentation page](https://www.nhcarrigan.com/BeccaBot-documentation) needs an update. If it does, please [create an issue there](https://github.com/nhcarrigan/BeccaBot-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [x] My contribution does NOT require a documentation update.
- [ ] My contribution DOES require a documentation update.