### PR TITLE
Fix/broken event test

### DIFF
--- a/test/unit/commands/bot/support.spec.ts
+++ b/test/unit/commands/bot/support.spec.ts
@@ -4,7 +4,7 @@ import { createSandbox, SinonStub } from "sinon";
 import cmd from "@Commands/bot/support";
 import { buildMessageInt } from "../../../testSetup";
 
-describe("command: report", () => {
+describe("command: support", () => {
   let sandbox;
   const testPrefix = "☂";
   const botColor = "7B25AA";
@@ -38,8 +38,8 @@ describe("command: report", () => {
   });
 
   context("when command followed by extra text", () => {
-    const inviteWithExtra = `${baseCommand} hello world`;
     it("should call send", async () => {
+      const inviteWithExtra = `${baseCommand} hello world`;
       const message = buildMessageInt(inviteWithExtra, "", "", botColor);
       const send: SinonStub = sandbox.stub();
       message.channel.send = send;

--- a/test/unit/events/onMessage.spec.ts
+++ b/test/unit/events/onMessage.spec.ts
@@ -1,4 +1,4 @@
-import { SinonSandbox, createSandbox, SinonStub, clock } from "sinon";
+import { SinonSandbox, createSandbox, SinonStub, replace } from "sinon";
 import { mock, reset } from "ts-mockito";
 import { expect } from "chai";
 import * as discordjs from "discord.js";
@@ -7,6 +7,7 @@ import CommandInt from "@Interfaces/CommandInt";
 import ListenerInt from "@Interfaces/ListenerInt";
 import onMessage from "@Events/onMessage";
 import { getListeners } from "@Utils/readDirectory";
+import SettingModel from "@Models/SettingModel";
 
 describe("onMessage event", () => {
   const testPrefix = "☂";
@@ -28,10 +29,12 @@ describe("onMessage event", () => {
   beforeEach(() => {
     sandbox = createSandbox();
     sandbox.useFakeTimers();
+    sandbox.replace(SettingModel, "findOne", sandbox.stub().resolves());
   });
 
   afterEach(() => {
     reset();
+    sandbox.clock.restore();
     sandbox.restore();
   });
 
@@ -39,11 +42,12 @@ describe("onMessage event", () => {
     it("should call run on interceptableLevelsListener", async () => {
       const aboutStub = sandbox.stub().resolves();
       const client = mock<discordjs.Client>();
-      const msg = mock<discordjs.Message>();
+      const msg = mock<discordjs.Message>({ send: sandbox.stub() });
       msg.content = `${testPrefix}about`;
       msg.attachments = new discordjs.Collection();
       msg.channel.startTyping = sandbox.stub();
       msg.channel.stopTyping = sandbox.stub();
+      msg.channel.send = sandbox.stub().resolves();
       msg.guild.id = "server_id";
 
       const clientInt = extendsClientToClientInt(client);
@@ -76,6 +80,7 @@ describe("onMessage event", () => {
       msg.attachments = new discordjs.Collection();
       msg.channel.startTyping = sandbox.stub();
       msg.channel.stopTyping = sandbox.stub();
+      msg.channel.send = sandbox.stub().resolves();
       msg.guild.id = "server_id";
 
       const clientInt = extendsClientToClientInt(client);
@@ -200,6 +205,7 @@ describe("onMessage event", () => {
         msg.attachments = new discordjs.Collection();
         msg.channel.startTyping = sandbox.stub();
         msg.channel.stopTyping = sandbox.stub();
+        msg.channel.send = sandbox.stub();
         msg.guild.id = "server_id";
 
         const clientInt = extendsClientToClientInt(client);
@@ -232,6 +238,7 @@ describe("onMessage event", () => {
       msg.attachments = new discordjs.Collection();
       msg.channel.startTyping = sandbox.stub();
       msg.channel.stopTyping = sandbox.stub();
+      msg.channel.send = sandbox.stub();
       msg.guild.id = "server_id";
 
       const clientInt = extendsClientToClientInt(client);


### PR DESCRIPTION
# Pull Request

## Description:

Follow seem to be causing the CI errors:
1. rouge promise => SettingsModel used to not be a thing when this test was first created so it wasn't accounting for it
2. extra send? It looks like there were some new situations where a send could happen, or at least they weren't accounted for/expected in the tests so the stub wasn't set up

## Related Issue:

Closes #272

## Scope:

Did you remember to update the `package.json` version number?

- [ ] Major Version Update: X.\_.\_ (for complete code refactors, or large PRs that adjust most of the codebase)
- [ ] Minor Version Update: \_.X.\_ (for the addition of new commands)
- [ ] Patch Version Update: \_.\_.X (for bug fixes _in the code_.)
- [x] No Version Update: \_.\_.\_ (no version update for additions to tests, documentation, or anything that isn't end-user facing.)

## Code Coverage:

Are all the unit tests passing and have you added tests that cover your changes? Run `npm run coverage`

Coverage Checklist:

- [x] All unit tests passing
- [x] Code that my PR modifies has tests.
- [x] PR defines validation steps.

### Validation Notes

Tests in pipeline and locally should pass.

## Documentation:

For _any_ version updates, please verify if the [documentation page](https://www.nhcarrigan.com/BeccaBot-documentation) needs an update. If it does, please [create an issue there](https://github.com/nhcarrigan/BeccaBot-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [x] My contribution does NOT require a documentation update.
- [ ] My contribution DOES require a documentation update.
